### PR TITLE
Add diffusion-based depth and flow prototype

### DIFF
--- a/docs/source/diffusion_depth_flow.rst
+++ b/docs/source/diffusion_depth_flow.rst
@@ -1,0 +1,21 @@
+Diffusion-based Depth and Optical Flow
+======================================
+
+Torchvision provides an experimental module for estimating depth and optical
+flow with an iterative diffusion-style process. The implementation is inspired
+by recent research on applying denoising diffusion models to geometric tasks.
+It refines random depth and flow predictions conditioned on the input image.
+
+Example usage::
+
+    import torch
+    from torchvision.models import DiffusionDepthFlowEstimator
+
+    model = DiffusionDepthFlowEstimator(num_steps=3)
+    img = torch.randn(1, 3, 64, 64)
+    depth, flow = model(img)
+
+The code is intentionally lightweight and is **not** a replacement for full
+state-of-the-art implementations described in the latest literature. It serves
+as a simple demonstration of the technique so users can experiment with
+iterative refinement approaches.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ architectures, and common image transformations for computer vision.
    models
    transforms
    utils
+   diffusion_depth_flow
 
 .. automodule:: torchvision
    :members:

--- a/test/test_diffusion_depth_flow.py
+++ b/test/test_diffusion_depth_flow.py
@@ -1,0 +1,14 @@
+import unittest
+import torch
+import torchvision.models as models
+
+class Tester(unittest.TestCase):
+    def test_forward_shapes(self):
+        model = models.DiffusionDepthFlowEstimator(num_steps=2)
+        img = torch.randn(1, 3, 32, 32)
+        depth, flow = model(img)
+        self.assertEqual(depth.shape, (1, 1, 32, 32))
+        self.assertEqual(flow.shape, (1, 2, 32, 32))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/torchvision/models/__init__.py
+++ b/torchvision/models/__init__.py
@@ -4,3 +4,5 @@ from .vgg import *
 from .squeezenet import *
 from .inception import *
 from .densenet import *
+
+from .diffusion_depth_flow import *

--- a/torchvision/models/diffusion_depth_flow.py
+++ b/torchvision/models/diffusion_depth_flow.py
@@ -1,0 +1,46 @@
+import torch
+import torch.nn as nn
+
+class DiffusionDepthFlowEstimator(nn.Module):
+    """Experimental diffusion-based estimator for depth and optical flow.
+
+    This module implements a simple iterative refinement scheme inspired by
+    diffusion models. It is **not** a full reproduction of any particular
+    research paper, but provides a lightweight demonstration of how one might
+    approach depth and optical flow estimation with iterative denoising.
+    """
+
+    def __init__(self, num_steps=5, hidden_channels=32):
+        super(DiffusionDepthFlowEstimator, self).__init__()
+        self.num_steps = num_steps
+        self.depth_net = nn.Sequential(
+            nn.Conv2d(3 + 1, hidden_channels, 3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(hidden_channels, 1, 3, padding=1)
+        )
+        self.flow_net = nn.Sequential(
+            nn.Conv2d(3 + 2, hidden_channels, 3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(hidden_channels, 2, 3, padding=1)
+        )
+
+    def forward(self, image):
+        """Estimate depth and optical flow for ``image``.
+
+        Args:
+            image (Tensor): Input tensor of shape ``(N, 3, H, W)``.
+
+        Returns:
+            Tuple[Tensor, Tensor]: Estimated depth of shape ``(N, 1, H, W)`` and
+            optical flow of shape ``(N, 2, H, W)``.
+        """
+        N, C, H, W = image.shape
+        device = image.device
+        depth = torch.randn(N, 1, H, W, device=device)
+        flow = torch.randn(N, 2, H, W, device=device)
+        for _ in range(self.num_steps):
+            depth_input = torch.cat([image, depth], dim=1)
+            depth = depth + self.depth_net(depth_input)
+            flow_input = torch.cat([image, flow], dim=1)
+            flow = flow + self.flow_net(flow_input)
+        return depth, flow


### PR DESCRIPTION
## Summary
- prototype `DiffusionDepthFlowEstimator` module for depth and optical flow
- expose new model through `torchvision.models`
- document diffusion module
- test forward output shapes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68437ee5965c8327a0c29192e75b9f36